### PR TITLE
add: screenshot APIとの接続

### DIFF
--- a/app/controllers/web_apps_controller.rb
+++ b/app/controllers/web_apps_controller.rb
@@ -8,6 +8,25 @@ class WebAppsController < ApplicationController
 
   def create
     @web_app = WebApp.new(web_app_params)
+
+    options = {
+      fullpage: 1, 
+      width: "", 
+      viewport: "", 
+      format: "", 
+      css_url: "", 
+      delay: 3, 
+      ttl: "", 
+      force: "", 
+      placeholder: "", 
+      user_agent: "", 
+      accept_lang: "", 
+      export: "" 
+    }
+
+    screenshot_url = ScreenshotService.screenshotlayer(@web_app.url, options)
+    @web_app.remote_screenshot_url = screenshot_url
+  
     if @web_app.save
       redirect_to web_app_path(@web_app), notice: "Webアプリを登録しました"
     else

--- a/app/controllers/web_apps_controller.rb
+++ b/app/controllers/web_apps_controller.rb
@@ -54,6 +54,6 @@ class WebAppsController < ApplicationController
   end
 
   def web_app_params
-    params.require(:web_app).permit(:site_name, :url, :ogp_title, :ogp_description, :ogp_image, :screenshot, :offer_date)
+    params.require(:web_app).permit(:site_name, :url, :ogp_title, :ogp_description, :ogp_image, :offer_date)
   end
 end

--- a/app/services/screenshot_service.rb
+++ b/app/services/screenshot_service.rb
@@ -1,0 +1,41 @@
+class ScreenshotService
+  require 'cgi' unless defined?(CGI)
+  require 'digest' unless defined?(Digest)
+
+  def self.screenshotlayer(url, options={})
+
+    # set access key
+    access_key = ENV['SCREENSHOTLAYER_ACCESS_KEY']
+    
+    # set secret keyword (defined in account dashboard)
+    secret_keyword = ENV['SCREENSHOTLAYER_SECRET_KEYWORD']
+  
+    # define parameters
+    parameters = {
+      :url       => url,
+      :fullpage  => options[:fullpage],
+      :width  => options[:width],
+      :viewport  => options[:viewport],
+      :format  => options[:format],
+      :css_url  => options[:css_url],
+      :delay  => options[:delay],
+      :ttl  => options[:ttl],
+      :force  => options[:force],
+      :placeholder  => options[:placeholder],
+      :user_agent  => options[:user_agent],
+      :accept_lang  => options[:accept_lang],
+      :export  => options[:export],
+    }
+    
+    query = parameters.
+      sort_by {|s| s[0].to_s }. 
+      select {|s| s[1] }.       
+      map {|s| s.map {|v| CGI::escape(v.to_s) }.join('=') }.
+      join('&')
+    
+    # generate md5 secret key
+    secret_key = Digest::MD5.hexdigest(url + secret_keyword)
+  
+    "https://api.screenshotlayer.com/api/capture?access_key=#{access_key}&secret_key=#{secret_key}&#{query}"
+  end
+end

--- a/app/uploaders/screenshot_uploader.rb
+++ b/app/uploaders/screenshot_uploader.rb
@@ -37,9 +37,9 @@ class ScreenshotUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/web_apps/new.html.erb
+++ b/app/views/web_apps/new.html.erb
@@ -20,10 +20,6 @@
     <%= f.text_field :ogp_image %>
   </div>
   <div class="field">
-    <%= f.label :screenshot %>
-    <%= f.file_field :screenshot %>
-  </div>
-  <div class="field">
     <%= f.label :offer_date %>
     <%= f.date_field :offer_date %>
   </div>


### PR DESCRIPTION
Closes #20 
仮で作成した、web_app作成について、そのフォームで入力したURLからscreenshot APIを通してそのサイトのスクショを取得。web_appsテーブルのscreenshotカラム(carrierwave)に保存されるように実装。
- [x] web_apps/new画面で、フォームを送信し、成功することを確認。

※なお、開発環境ではなぜか失敗するが、本番環境では問題ない。