### PR TITLE
add: webappの提供日の自動更新処理

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -3,7 +3,9 @@ class MypagesController < ApplicationController
 
   def show
     start_date = params.fetch(:start_date, Date.today).to_date
-    @web_apps_with_reviews = WebApp.joins(:reviews).where(reviews: { user_id: current_user.id }).where(offer_date: start_date.beginning_of_month..start_date.end_of_month)
+    @reviews = Review.includes(:web_app)
+                     .where(user_id: current_user.id)
+                     .where(webapp_offer_date: start_date.beginning_of_month..start_date.end_of_month)
   end
 
   def bookmark

--- a/app/controllers/web_apps_controller.rb
+++ b/app/controllers/web_apps_controller.rb
@@ -17,6 +17,6 @@ class WebAppsController < ApplicationController
   end
 
   def set_review
-    @review = @web_app.reviews.find_by(user_id: current_user.id)
+    @review = @web_app.reviews.find_by(user_id: current_user.id, webapp_offer_date: @web_app.offer_date)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,5 +4,17 @@ class Review < ApplicationRecord
 
   validates :originality_score, :usability_score, :design_score,
             numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
-  validates :user_id, uniqueness: { scope: :web_app_id }
+  validates :user_id, uniqueness: { scope: [ :web_app_id, :webapp_offer_date ] }
+
+  before_create :set_webapp_offer_date
+
+  def start_time
+    self.webapp_offer_date
+  end
+
+  private
+
+  def set_webapp_offer_date
+    self.webapp_offer_date = web_app.offer_date
+  end
 end

--- a/app/models/web_app.rb
+++ b/app/models/web_app.rb
@@ -6,8 +6,4 @@ class WebApp < ApplicationRecord
   validates :site_name, presence: true
   validates :url, presence: true, uniqueness: true
   validates :status, presence: true
-
-  def start_time
-    self.offer_date
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,9 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <%= render 'shared/flash_message' %>
-    <%= yield %>
+    <div class="bg-white">
+      <%= yield %>
+    </div>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/mypages/notification.html.erb
+++ b/app/views/mypages/notification.html.erb
@@ -24,7 +24,7 @@
         </div>
       </div>
     </div>
-  <div class="flex justify-center my-12">
+  <div class="flex justify-center mt-12 pb-12">
     <div class="border px-4 w-64 rounded-lg shadow-lg flex flex-col mt-4">
       <%= form_with(model: @user, url: setting_notify_mypage_path, method: :post, local: true) do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
@@ -43,7 +43,7 @@
         <%= link_to t('defaults.remove_notification'), remove_notify_mypage_path, data: {
                     turbo_method: :delete,
                     turbo_confirm: t('defaults.message.notify_remove_confirm') },
-                    class: "btn btn-xs text-red-500 mb-4" %>
+                    class: "btn btn-xs text-red-500 mb-4 dark:bg-white" %>
       <% end %>
     </div>
   </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -20,13 +20,15 @@
   </div>
 
   <h2 class="my-4 text-center text-xl font-bold text-gray-800 md:mb-6 lg:text-2xl pb-2 border-b-2">記録カレンダー</h2>
-  <%= month_calendar(events: @web_apps_with_reviews) do |date, web_apps| %>
+  <%= month_calendar(events: @reviews) do |date, reviews| %>
     <%= date.day %>
 
-    <% web_apps.each do |web_app| %>
-      <div>
-        <%= link_to web_app.site_name, web_app_path(web_app), class:"text-blue-500" %>
-      </div>
+    <% if date <= Date.today %>
+      <% reviews.each do |review| %>
+        <div>
+          <%= link_to review.web_app.site_name, web_app_path(review.web_app), class:"text-blue-500" %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -43,8 +43,8 @@
         <li>
           <div class="dropdown dropdown-end">
             <label tabindex="0" class="btn btn-ghost">
-              <div class="w-10 rounded-full">
-                <%= image_tag "header_menu.png", class: "md:h-8 h-6 mr-1" %>
+              <div class="rounded-full">
+                <%= image_tag "header_menu.png", class: "md:h-8 h-6" %>
               </div>
             </label>
             <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-50">

--- a/app/views/web_apps/_bookmark.html.erb
+++ b/app/views/web_apps/_bookmark.html.erb
@@ -1,5 +1,5 @@
 <%= link_to bookmarks_path(web_app_id: web_app.id), data: { turbo_method: "post" } do %>
-  <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 20">
+  <svg class="w-6 h-6 text-gray-800" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 20">
     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m13 19-6-5-6 5V2a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v17Z"/>
   </svg>
 <% end %>

--- a/app/views/web_apps/_unbookmark.html.erb
+++ b/app/views/web_apps/_unbookmark.html.erb
@@ -1,5 +1,5 @@
 <%= link_to bookmark_path(current_user.bookmarks.find_by(web_app_id: web_app.id)), data: { turbo_method: "delete" } do %>
-  <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 14 20">
+  <svg class="w-6 h-6 text-gray-800" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 14 20">
     <path d="M13 20a1 1 0 0 1-.64-.231L7 15.3l-5.36 4.469A1 1 0 0 1 0 19V2a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v17a1 1 0 0 1-1 1Z"/>
   </svg>
 <% end %>

--- a/app/views/web_apps/_web_app.html.erb
+++ b/app/views/web_apps/_web_app.html.erb
@@ -17,7 +17,11 @@
       <div class="mt-auto flex items-end justify-between">
         <div class="flex items-center gap-2">
           <div>
-            <span class="block text-indigo-500">提供日</span>
+            <% if web_app.offer_date > Date.today %>
+              <span class="block text-indigo-500">次回提供日</span>
+            <% else %>
+              <span class="block text-indigo-500">提供日</span>
+            <% end %>       
             <span class="block text-sm text-gray-400"><%= web_app.offer_date %></span>
           </div>
         </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  host = 'https://web-app-diary-387ded82e725.herokuapp.com/'
+  host = 'https://www.webappdiary.com/'
   config.action_mailer.default_url_options = { protocol: 'https', host: host }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp

--- a/db/migrate/20230901081026_add_webapp_offer_date_to_reviews.rb
+++ b/db/migrate/20230901081026_add_webapp_offer_date_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddWebappOfferDateToReviews < ActiveRecord::Migration[7.0]
+  def change
+    add_column :reviews, :webapp_offer_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_22_061930) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_01_081026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_22_061930) do
     t.boolean "is_counted", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "webapp_offer_date"
     t.index ["user_id"], name: "index_reviews_on_user_id"
     t.index ["web_app_id"], name: "index_reviews_on_web_app_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,15 +7,15 @@
 #   Character.create(name: "Luke", movie: movies.first)
 
 
-27.times do |n|
+30.times do |n|
   WebApp.create(
-    site_name: "サイト#{n + 1}",
-    url: "https://www.site#{n + 1}.com",
-    ogp_title: "サイト#{n + 1}のOGPタイトル",
-    ogp_description: "サイト#{n + 1}のOGPディスクリプション",
+    site_name: "サイト#{n + 28}",
+    url: "https://www.site#{n + 28}.com",
+    ogp_title: "サイト#{n + 28}のOGPタイトル",
+    ogp_description: "サイト#{n + 28}のOGPディスクリプション",
     ogp_image: "ogp_image.png",
     screenshot: "not_found.png",
-    offer_date: Date.new(2023, 8, 5) + n.days,
+    offer_date: Date.new(2023, 9, 1) + n.days,
     status: 0
   )
 end

--- a/lib/tasks/auto_update_offer_date.rake
+++ b/lib/tasks/auto_update_offer_date.rake
@@ -1,0 +1,24 @@
+namespace :web_apps do
+  desc "特定のweb_appのoffer_dateを更新"
+  task update_offer_date: :environment do
+    # 今日の日付から70日前の日付を取得
+    target_date = Date.today - 70.days
+
+    # 70日前に提供されたアプリを探す
+    web_app_to_update = WebApp.find_by(offer_date: target_date)
+
+    # 今あるweb_appの中で、一番遠くの日付を取得
+    latest_offer_date = WebApp.maximum(:offer_date)
+
+    # 新しいoffer_dateを計算（一番遠くの日付 + 1日）
+    new_offer_date = latest_offer_date + 1.day
+
+    # 70日前に提供されたアプリのoffer_dateを更新
+    if web_app_to_update
+      web_app_to_update.update(offer_date: new_offer_date)
+      puts "web_app (ID: #{web_app_to_update.id}) を新しいoffer_date: #{new_offer_date}に更新しました"
+    else
+      puts "offer_date: #{target_date}のweb_appはありませんでした"
+    end
+  end
+end

--- a/lib/tasks/line_notify.rake
+++ b/lib/tasks/line_notify.rake
@@ -18,7 +18,7 @@ namespace :line_notify do
 
       message = {
         type: 'text',
-        text: "新しいWebアプリが提供されています!\n確認しましょう!\n\nhttps://web-app-diary-387ded82e725.herokuapp.com/"
+        text: "新しいWebアプリが提供されています!\n確認しましょう!\n\nhttps://www.webappdiary.com/web_apps/todayapp"
       }
       response = client.push_message(user.uid, message)
       p response

--- a/lib/tasks/update_webapp_offer_date.rake
+++ b/lib/tasks/update_webapp_offer_date.rake
@@ -1,8 +1,8 @@
-namespace :db do
-  desc "Update webapp_offer_date in reviews table"
-  task update_webapp_offer_date: :environment do
-    Review.find_each do |review|
-      review.update(webapp_offer_date: review.web_app.offer_date)
-    end
-  end
-end
+# namespace :db do
+#   desc "Update webapp_offer_date in reviews table"
+#   task update_webapp_offer_date: :environment do
+#     Review.find_each do |review|
+#       review.update(webapp_offer_date: review.web_app.offer_date)
+#     end
+#   end
+# end

--- a/lib/tasks/update_webapp_offer_date.rake
+++ b/lib/tasks/update_webapp_offer_date.rake
@@ -1,0 +1,8 @@
+namespace :db do
+  desc "Update webapp_offer_date in reviews table"
+  task update_webapp_offer_date: :environment do
+    Review.find_each do |review|
+      review.update(webapp_offer_date: review.web_app.offer_date)
+    end
+  end
+end


### PR DESCRIPTION
Closes #94 
[MVPレビュー](https://github.com/hiroshi-okimura/web_app_diary/issues/91#:~:text=webapp%E3%81%AEoffer_date%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6%E3%80%81webapp%E3%81%AE%E5%85%A8%E4%BD%93%E3%81%AE%E6%95%B0%E6%AC%A1%E7%AC%AC%E3%81%A7%E5%86%8D%E5%BA%A6%E6%9B%B4%E6%96%B0%E3%81%99%E3%82%8B%E3%81%AA%E3%81%A9%E3%81%97%E3%81%A61%E6%97%A51%E3%82%A2%E3%83%97%E3%83%AA%E3%82%92%E7%B4%B9%E4%BB%8B%E3%81%99%E3%82%8B%E3%82%88%E3%81%86%E3%81%AA%E6%84%9F%E3%81%98%E3%81%8B%E3%81%AA%E3%81%A8%E6%80%9D%E3%81%86%E3%81%AE%E3%81%A7%E3%80%81%E3%83%90%E3%83%83%E3%83%81%E5%87%A6%E7%90%86%E3%81%AA%E3%81%A9%E3%81%A7%E3%80%81%E8%87%AA%E5%8B%95%E7%9A%84%E3%81%AB%E6%9B%B4%E6%96%B0%E3%81%95%E3%82%8C%E3%82%8B%E5%87%A6%E7%90%86%E3%81%AA%E3%81%A9%E4%BD%9C%E3%82%8B%E3%81%A8%E8%89%AF%E3%81%95%E3%81%9D%E3%81%86%E3%81%A7%E3%81%99%E3%80%82%EF%BC%88%E3%82%82%E3%81%97web%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E6%95%B0%E3%81%8C%E8%B6%B3%E3%82%8A%E3%81%AA%E3%81%8F%E3%81%AA%E3%81%A3%E3%81%9F%E5%A0%B4%E5%90%88%E3%82%92%E6%83%B3%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%AE%E8%A9%B1%EF%BC%89)の内容を実装。
提供されてから、70日経ったアプリのoffer_dateを、今ストックされているアプリの中で最新のoffer_date自動的に更新。
それを、1日1回Rakeタスクで、実行。
開発環境での実行結果↓
```
o.hiroshi@ohiroshiMacBook-Pro web_app_diary % rake web_apps:update_offer_date
web_app (ID: 13) を新しいoffer_date: 2023-10-02に更新しました
o.hiroshi@ohiroshiMacBook-Pro web_app_diary % rake web_apps:update_offer_date
offer_date: 2023-08-10のweb_appはありませんでした
```
本番環境では、Heroku Schedulerを使用。

Closes #98 
独自ドメインの取得による一部修正　[d1d0072ee4dfaa7d3a5082499bc5dc80fcb1b1ff](https://github.com/hiroshi-okimura/web_app_diary/commit/d1d0072ee4dfaa7d3a5082499bc5dc80fcb1b1ff)